### PR TITLE
Fix "could not find assembly 'platform.winmd'" in Visual Studio 2017 Community 15.5.4

### DIFF
--- a/DigitalSigning/DigitalSigning/DigitalSigning.vcxproj
+++ b/DigitalSigning/DigitalSigning/DigitalSigning.vcxproj
@@ -90,7 +90,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalUsingDirectories>$(SystemDrive)\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\IDE\VC\vcpackages;$(SystemDrive)\Program Files (x86)\Windows Kits\10\UnionMetadata;$(SystemDrive)\Program Files (x86)\Windows Kits\10\References\Windows.Foundation.UniversalApiContract\1.0.0.0;$(SystemDrive)\Program Files (x86)\Windows Kits\10\References\Windows.Foundation.FoundationContract\1.0.0.0;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <AdditionalUsingDirectories>$(SystemDrive)\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\vcpackages;$(SystemDrive)\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\IDE\VC\vcpackages;$(SystemDrive)\Program Files (x86)\Windows Kits\10\UnionMetadata;$(SystemDrive)\Program Files (x86)\Windows Kits\10\References\Windows.Foundation.UniversalApiContract\1.0.0.0;$(SystemDrive)\Program Files (x86)\Windows Kits\10\References\Windows.Foundation.FoundationContract\1.0.0.0;%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <CompileAsWinRT>true</CompileAsWinRT>
       <MinimalRebuild>false</MinimalRebuild>
     </ClCompile>


### PR DESCRIPTION
Resolves #17.