### PR TITLE
Update Edge Extension Tutorials to use Manifest V3

### DIFF
--- a/extension-getting-started-part1/part1/manifest.json
+++ b/extension-getting-started-part1/part1/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "NASA Picture of the day viewer",
   "version": "0.0.0.1",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "description": "A chromium extension to show NASA's Picture of the Day.",
   "icons": {
     "16": "icons/nasapod16x16.png",
@@ -9,7 +9,7 @@
     "48": "icons/nasapod48x48.png",
     "128": "icons/nasapod128x128.png"
   },
-  "browser_action": {
+  "action": {
     "default_popup": "popup/popup.html"
   }
 }

--- a/extension-getting-started-part2/extension-getting-started-part2/manifest.json
+++ b/extension-getting-started-part2/extension-getting-started-part2/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "NASA Picture of the day viewer",
-  "version": "0.0.0.2",
+  "version": "0.0.0.1",
   "manifest_version": 3,
   "description": "A chromium extension to show NASA's Picture of the Day.",
   "icons": {

--- a/extension-getting-started-part2/extension-getting-started-part2/manifest.json
+++ b/extension-getting-started-part2/extension-getting-started-part2/manifest.json
@@ -20,7 +20,7 @@
       "js": ["lib/jquery.min.js","content-scripts/content.js"]
     }
   ],
-  "web_accessible_resources": [ 
+  "web_accessible_resources": [
     {
       "resources": ["images/*.jpeg"],
       "matches": ["<all_urls>"]

--- a/extension-getting-started-part2/extension-getting-started-part2/manifest.json
+++ b/extension-getting-started-part2/extension-getting-started-part2/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "NASA Picture of the day viewer",
-  "version": "0.0.0.1",
-  "manifest_version": 2,
+  "version": "0.0.0.2",
+  "manifest_version": 3,
   "description": "A chromium extension to show NASA's Picture of the Day.",
   "icons": {
     "16": "icons/nasapod16x16.png",
@@ -9,7 +9,7 @@
     "48": "icons/nasapod48x48.png",
     "128": "icons/nasapod128x128.png"
   },
-  "browser_action": {
+  "action": {
     "default_popup": "popup/popup.html"
   },
   "content_scripts": [
@@ -20,7 +20,10 @@
       "js": ["lib/jquery.min.js","content-scripts/content.js"]
     }
   ],
-  "web_accessible_resources": [
-    "images/*.jpeg"
+  "web_accessible_resources": [ 
+    {
+      "resources": ["images/*.jpeg"],
+      "matches": ["<all_urls>"]
+    }
   ]
 }

--- a/extension-getting-started-part2/extension-getting-started-part2/popup/popup.js
+++ b/extension-getting-started-part2/extension-getting-started-part2/popup/popup.js
@@ -5,7 +5,7 @@ if (sendMessageId) {
       chrome.tabs.sendMessage(
         tabs[0].id,
         {
-          url: chrome.extension.getURL("images/stars.jpeg"),
+          url: chrome.runtime.getURL("images/stars.jpeg"),
           imageDivId: `${guidGenerator()}`,
           tabId: tabs[0].id
         },


### PR DESCRIPTION
This PR combines similar asks in #30 and #33 to update the tutorials in Microsoft to use the latest manifest format, and replaces any deprecated functions.

Tutorials linked to repo:
* [Create an extension tutorial, part 1](https://docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/getting-started/part1-simple-extension)
* [Create an extension tutorial, part 2](https://docs.microsoft.com/en-us/microsoft-edge/extensions-chromium/getting-started/part2-content-scripts)